### PR TITLE
Change job role to Technology Evangelist

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,18 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Ralf D. Müller - Software Engineering Advocate, docToolchain Creator, arc42 Committer und Co-Host bei software-architektur.tv">
+    <meta name="description" content="Ralf D. Müller - Technology Evangelist, docToolchain Creator, arc42 Committer und Co-Host bei software-architektur.tv">
     <link rel="canonical" href="https://rdmueller.github.io/index.html">
     <meta property="og:url" content="https://rdmueller.github.io/index.html">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Ralf D. Müller | Software Engineering Advocate">
-    <meta property="og:description" content="Software Engineering Advocate, docToolchain Creator, arc42 Committer und Co-Host bei software-architektur.tv">
+    <meta property="og:title" content="Ralf D. Müller | Technology Evangelist">
+    <meta property="og:description" content="Technology Evangelist, docToolchain Creator, arc42 Committer und Co-Host bei software-architektur.tv">
     <meta property="og:image" content="https://rdmueller.github.io/images/ralf-mueller.jpg">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Ralf D. Müller | Software Engineering Advocate">
-    <meta name="twitter:description" content="Software Engineering Advocate, docToolchain Creator, arc42 Committer und Co-Host bei software-architektur.tv">
+    <meta name="twitter:title" content="Ralf D. Müller | Technology Evangelist">
+    <meta name="twitter:description" content="Technology Evangelist, docToolchain Creator, arc42 Committer und Co-Host bei software-architektur.tv">
     <meta name="twitter:image" content="https://rdmueller.github.io/images/ralf-mueller.jpg">
-    <title>Ralf D. Müller | Software Engineering Advocate</title>
+    <title>Ralf D. Müller | Technology Evangelist</title>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -67,7 +67,7 @@
         <div class="container">
             <div class="hero-content">
                 <div class="hero-text">
-                    <p class="hero-subtitle">Software Engineering Advocate</p>
+                    <p class="hero-subtitle">Technology Evangelist</p>
                     <h1>Ralf D. Müller</h1>
                     <p class="hero-description">
                         Ich mache die Software-Welt ein Dokument nach dem anderen besser.
@@ -95,7 +95,7 @@
                     <p>
                         Mit über <strong>25 Jahren Erfahrung</strong> in der IT-Branche liegt mein Fokus auf der
                         Verbesserung der Produktivität in Software-Entwicklung und -Architektur. Tagsüber bin ich
-                        Software Engineering Advocate bei <a href="https://www.dbsystel.de" target="_blank" rel="noopener"><strong>DB Systel GmbH</strong></a>, abends liebe ich alles
+                        Technology Evangelist bei <a href="https://www.dbsystel.de" target="_blank" rel="noopener"><strong>DB Systel GmbH</strong></a>, abends liebe ich alles
                         mit Bits und Bytes.
                     </p>
                     <p>


### PR DESCRIPTION
## Summary
- Replaces "Software Engineering Advocate" with "Technology Evangelist" across `index.html` (meta description, OG tags, Twitter tags, `<title>`, hero subtitle, and the "Über mich" paragraph)

## Test plan
- [ ] Visual check: hero subtitle reads "Technology Evangelist"
- [ ] View page source: meta/OG/Twitter tags updated
- [ ] Social preview (LinkedIn/Twitter card validator) shows new title

🤖 Generated with [Claude Code](https://claude.com/claude-code)