### PR TITLE
manifesto: persönliches GenAI-Manifest v0.9

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
             <a href="index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="#about">Über mich</a></li>
+                <li><a href="pages/manifesto.html">Manifest</a></li>
                 <li><a href="#trainings">Trainings</a></li>
                 <li><a href="#talks">Vorträge</a></li>
                 <li><a href="#publications">Publikationen</a></li>
@@ -117,6 +118,10 @@
                         <li>docToolchain</li>
                         <li>GenAI & LLMs</li>
                     </ul>
+                    <p class="about-cta">
+                        Wofür ich bei GenAI stehe, habe ich in einem
+                        <a href="pages/manifesto.html"><strong>persönlichen Manifest</strong></a> festgehalten.
+                    </p>
                 </div>
             </div>
         </div>

--- a/pages/manifesto.html
+++ b/pages/manifesto.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Mein GenAI-Manifest. Persönliche Haltung von Ralf D. Müller zu Intelligenz, AGI, Engineering-Disziplin, Verantwortung und der Kennzeichnungspflicht.">
+    <link rel="canonical" href="https://rdmueller.github.io/pages/manifesto.html">
+    <meta property="og:url" content="https://rdmueller.github.io/pages/manifesto.html">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Mein GenAI-Manifest | Ralf D. Müller">
+    <meta property="og:description" content="Für mich zählt das Erreichte und reicht nicht das Erzählte. Persönliche Haltung zu GenAI in der Software-Entwicklung.">
+    <meta property="og:image" content="https://rdmueller.github.io/images/ralf-mueller.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Mein GenAI-Manifest | Ralf D. Müller">
+    <meta name="twitter:description" content="Für mich zählt das Erreichte und reicht nicht das Erzählte.">
+    <meta name="twitter:image" content="https://rdmueller.github.io/images/ralf-mueller.jpg">
+    <title>Mein GenAI-Manifest | Ralf D. Müller</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "name": "Mein GenAI-Manifest",
+      "description": "Persönliche Haltung von Ralf D. Müller zu GenAI in der Software-Entwicklung.",
+      "url": "https://rdmueller.github.io/pages/manifesto.html",
+      "inLanguage": "de",
+      "author": {
+        "@type": "Person",
+        "name": "Ralf D. Müller",
+        "url": "https://rdmueller.github.io/"
+      }
+    }
+    </script>
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+    <link rel="stylesheet" href="../css/style.min.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script data-goatcounter="https://rdmueller.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="container">
+            <a href="../index.html" class="logo">Ralf D. Müller</a>
+            <ul class="nav-links">
+                <li><a href="../index.html#about">Über mich</a></li>
+                <li><a href="manifesto.html" class="active">Manifest</a></li>
+                <li><a href="../index.html#trainings">Trainings</a></li>
+                <li><a href="../index.html#talks">Vorträge</a></li>
+                <li><a href="../index.html#publications">Publikationen</a></li>
+                <li><a href="blog.html">Ralf's Corner</a></li>
+                <li><a href="elfi.html">Elfi's Corner</a></li>
+                <li><a href="../index.html#contact">Kontakt</a></li>
+            </ul>
+            <button class="mobile-menu-btn" aria-label="Menü öffnen">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
+    </nav>
+
+    <main class="article-page">
+        <article class="container">
+            <header class="article-header">
+                <div class="article-meta">
+                    <span class="lang-badge">DE</span>
+                    <span class="article-date">Persönliche Fassung v0.9</span>
+                </div>
+                <h1>Mein GenAI-Manifest</h1>
+                <p class="article-lead"><em>Für mich zählt das Erreichte und reicht nicht das Erzählte.</em></p>
+            </header>
+
+            <div class="article-content">
+                <p>Ich bin Software-Architekt. Ich habe aufgehört zu fragen, <em>was</em> GenAI ist, und angefangen zu nutzen, <em>was</em> sie kann.</p>
+
+                <p>Die spannende Diskussion ist weitergezogen. Ich ziehe mit.</p>
+
+                <h2>Meine Haltung</h2>
+
+                <p><strong>Ich akzeptiere GenAI als eine Form von Intelligenz.</strong><br>
+                Ob sie „wirklich" intelligent ist, bringt mich nicht weiter. Ich schaue, was die Systeme leisten — und arbeite damit.</p>
+
+                <p><strong>Ich definiere Fähigkeiten unabhängig vom Menschen.</strong><br>
+                Begriffe wie Kreativität, Verständnis und Intelligenz fest an den Menschen zu binden — „Kreativität ist, was Menschen tun" — engt das Denken ein und macht neue Formen unsichtbar, bevor man hinsieht. Ich messe solche Fähigkeiten an ihren Eigenschaften und Wirkungen, nicht an ihrer Herkunft. Das nimmt dem Menschen nichts — es weitet den Blick.</p>
+
+                <p><strong>Ich warte nicht auf AGI.</strong><br>
+                Auf einen Begriff zu warten, den niemand definieren kann, ist keine Strategie, sondern eine Ausrede. Ich arbeite mit dem, was heute auf dem Tisch liegt — und das ist mehr als genug.</p>
+
+                <p><strong>Die Büchse der Pandora ist offen.</strong><br>
+                GenAI ist in der Welt — und niemand fängt sie wieder ein. Die Frage ist nicht <em>ob</em>, sondern <em>wie</em>. Ich antizipiere und gestalte, statt zu warten, bis „sich das alles beruhigt". Das tut es nicht.</p>
+
+                <p><strong>Ich wende GenAI nicht blind an — ich verstehe sie.</strong><br>
+                GenAI sinnvoll einzusetzen ist eine Ingenieursdisziplin: Man liest keine Spezifikation, man untersucht ein Verhalten. Also gehe ich empirisch vor und will wissen, <em>warum</em> etwas funktioniert, <em>wo</em> es bricht und <em>wann</em> man ihm nicht trauen darf. Das schützt vor dem Cargo-Kult auf der einen und der Angst auf der anderen Seite.</p>
+
+                <p><strong>Ich bringe Handwerk mit, nicht nur Begeisterung.</strong><br>
+                Ein Sprachmodell ersetzt keine Architektur, keine Klarheit über das Problem, keine Disziplin im Bauen. Genau das bringe ich ein. Die Werkzeuge sind neu — der Anspruch an gute Arbeit ist es nicht.</p>
+
+                <p><strong>Ich setze GenAI für Menschen ein, nicht gegen sie.</strong><br>
+                Ich messe sie nicht an dem, was sie verspricht, sondern an dem, was sie tut, wenn es etwas kostet. KI, die Menschen überwacht, herabwürdigt oder mit Desinformation flutet — oder ohne menschliche Verantwortung losgelassen wird — ist nicht, was ich meine. Gleich, wessen Logo darauf klebt.</p>
+
+                <p><strong>Echte Kontrolle schlägt das Ritual der Kontrolle.</strong><br>
+                Ein erzwungenes Review, das in Review-Fatigue verläuft, ist erzählte Sicherheit — ein Haken ohne Substanz. Wo menschliche Prüfung nicht mehr echt greift, baue ich die Sicherheit in den Prozess: in Tests, in Architektur, in Abläufe, die Fehler abfangen. Der Mensch ist nicht das Gate, sondern der, der das System so baut, dass es trägt.</p>
+
+                <p><strong>Die Pflicht, KI zu kennzeichnen, wird sich selbst überholen.</strong><br>
+                Heute soll eine Markierung warnen: „hier war eine Maschine". Wenn aber bald alles KI-berührt ist, markiert sie nichts mehr — eine Warnung auf allem ist keine Warnung. Was zählt, wandert von der Herkunft zur Sorgfalt: nicht <em>ob</em> eine Maschine beteiligt war, sondern <em>wie</em> geprüft wurde.</p>
+
+                <h2>Kurz gesagt</h2>
+
+                <blockquote>
+                    <p>Verstehen über Bestaunen.<br>
+                    Bauen über Debattieren.<br>
+                    Fähigkeit über Etikett.<br>
+                    Handeln über Versprechen.<br>
+                    Heute über irgendwann.</p>
+                </blockquote>
+
+                <h2>Worüber ich reden will</h2>
+
+                <p>Wenn du mir beim Abendessen erklären willst, warum „die KI ja gar nicht wirklich versteht" — das ist ein interessantes Gespräch. Es ist nur nicht <em>meins</em>.</p>
+
+                <p>Wenn du mir lieber zeigst, was du letzte Woche damit gebaut hast: jederzeit.</p>
+            </div>
+
+            <footer class="article-footer">
+                <nav class="article-nav">
+                    <a href="../index.html" class="back-link">← Zurück zur Startseite</a>
+                </nav>
+            </footer>
+        </article>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <p>&copy; <span class="current-year">2026</span> Ralf D. Müller. Alle Rechte vorbehalten.</p>
+            <nav class="footer-nav">
+                <a href="impressum.html">Impressum</a>
+                <a href="datenschutz.html">Datenschutz</a>
+            </nav>
+        </div>
+    </footer>
+
+    <script src="../js/main.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://rdmueller.github.io/index.html</loc><lastmod>2026-03-26</lastmod></url>
+  <url><loc>https://rdmueller.github.io/index.html</loc><lastmod>2026-06-12</lastmod></url>
+  <url><loc>https://rdmueller.github.io/pages/manifesto.html</loc><lastmod>2026-06-12</lastmod></url>
   <url><loc>https://rdmueller.github.io/pages/blog.html</loc><lastmod>2026-03-26</lastmod></url>
   <url><loc>https://rdmueller.github.io/pages/talks.html</loc><lastmod>2026-03-26</lastmod></url>
   <url><loc>https://rdmueller.github.io/pages/hhgdac.html</loc><lastmod>2026-02-14</lastmod></url>


### PR DESCRIPTION
## Summary

- Eigene Seite `/pages/manifesto.html` mit Ralfs persönlichem GenAI-Manifest (Fassung v0.9)
- Verlinkt aus der Hauptnavigation und als Callout im Über-mich-Abschnitt von `index.html`
- Sitemap erweitert

## Inhaltliche Notiz

Header der Kernsektion ist "Meine Haltung" (statt "Woran ich glaube"), damit der Begriff "Glauben" nicht im Widerspruch zur Aussage des Manifests steht.

Mutigste Aussage bewusst gelassen: "Die Pflicht, KI zu kennzeichnen, wird sich selbst überholen." Eigenständige Position, kein versehentliches Diskussions-Sprengsel.

Bewusst nicht eingebaut: Brücke zu Semantic Anchors / dacli. Manifest soll keine Produkte verkaufen — Leser kann selbst verlinken.

## Test plan

- [x] `python3 -m http.server` smoke test: Seite liefert 200
- [x] Nav-Link und Callout-Link in `index.html` zeigen auf `pages/manifesto.html`
- [ ] Visuelle Prüfung im Browser (Typografie, Mobile-Nav, Blockquote-Styling)
- [ ] GoatCounter trackt die neue Seite nach dem Merge (ohne weitere Konfiguration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)