### PR TITLE
nav: introduce sync-nav script as single source of truth

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,14 +47,14 @@
         <div class="container">
             <a href="index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
-                <li><a href="#about">Über mich</a></li>
+                <li><a href="index.html#about">Über mich</a></li>
                 <li><a href="pages/manifesto.html">Manifest</a></li>
-                <li><a href="#trainings">Trainings</a></li>
-                <li><a href="#talks">Vorträge</a></li>
-                <li><a href="#publications">Publikationen</a></li>
+                <li><a href="index.html#trainings">Trainings</a></li>
+                <li><a href="pages/talks.html">Vorträge</a></li>
+                <li><a href="index.html#publications">Publikationen</a></li>
                 <li><a href="pages/blog.html">Ralf's Corner</a></li>
                 <li><a href="pages/elfi.html">Elfi's Corner</a></li>
-                <li><a href="#contact">Kontakt</a></li>
+                <li><a href="index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">
                 <span></span>

--- a/pages/blog.html
+++ b/pages/blog.html
@@ -28,10 +28,12 @@
             <a href="../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../index.html#about">Über mich</a></li>
+                <li><a href="../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../index.html#trainings">Trainings</a></li>
-                <li><a href="talks.html">Vorträge</a></li>
+                <li><a href="../pages/talks.html">Vorträge</a></li>
                 <li><a href="../index.html#publications">Publikationen</a></li>
-                <li><a href="blog.html" class="active">Blog</a></li>
+                <li><a href="../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/200-line-prompt.html
+++ b/pages/blog/200-line-prompt.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/200-stars.html
+++ b/pages/blog/200-stars.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/agents-vs-workflows.html
+++ b/pages/blog/agents-vs-workflows.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/ai-image-generation.html
+++ b/pages/blog/ai-image-generation.html
@@ -41,10 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/ai-inventory.html
+++ b/pages/blog/ai-inventory.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/ai-license-paradox.html
+++ b/pages/blog/ai-license-paradox.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/alternative-sicht-ki.html
+++ b/pages/blog/alternative-sicht-ki.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/arc42-ai-cockpit.html
+++ b/pages/blog/arc42-ai-cockpit.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/bausteinsicht-drawio.html
+++ b/pages/blog/bausteinsicht-drawio.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/bausteinsicht-launch.html
+++ b/pages/blog/bausteinsicht-launch.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/bettercode-panel-ki.html
+++ b/pages/blog/bettercode-panel-ki.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/claude-code-raspberry.html
+++ b/pages/blog/claude-code-raspberry.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/closed-loop-coding.html
+++ b/pages/blog/closed-loop-coding.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/code-is-worthless.html
+++ b/pages/blog/code-is-worthless.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/correction-loop.html
+++ b/pages/blog/correction-loop.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/dacli-llm-tool.html
+++ b/pages/blog/dacli-llm-tool.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/devcontainer-claude.html
+++ b/pages/blog/devcontainer-claude.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/digital-independence-day.html
+++ b/pages/blog/digital-independence-day.html
@@ -45,10 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/docs-as-code-training.html
+++ b/pages/blog/docs-as-code-training.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/doctoolchain-rb.html
+++ b/pages/blog/doctoolchain-rb.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/eichhorst-correction-radius.html
+++ b/pages/blog/eichhorst-correction-radius.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/eichhorst-language-choice.html
+++ b/pages/blog/eichhorst-language-choice.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/eichhorst-noiseless-channel.html
+++ b/pages/blog/eichhorst-noiseless-channel.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/eichhorst-purpose-vs-task.html
+++ b/pages/blog/eichhorst-purpose-vs-task.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/eichhorsts-principle.html
+++ b/pages/blog/eichhorsts-principle.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/elfi-blind-spots.html
+++ b/pages/blog/elfi-blind-spots.html
@@ -42,11 +42,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/elfi-brownfield-project.html
+++ b/pages/blog/elfi-brownfield-project.html
@@ -42,11 +42,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/elfi-c4boxes.html
+++ b/pages/blog/elfi-c4boxes.html
@@ -42,11 +42,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/elfi-docs-as-code.html
+++ b/pages/blog/elfi-docs-as-code.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html">Ralf's Corner</a></li>
-                <li><a href="../elfi.html" class="active">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/elfi-launch.html
+++ b/pages/blog/elfi-launch.html
@@ -42,11 +42,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/elfi-meeting.html
+++ b/pages/blog/elfi-meeting.html
@@ -42,11 +42,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/elfi-radar.html
+++ b/pages/blog/elfi-radar.html
@@ -42,11 +42,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/elfi-snack-anchors.html
+++ b/pages/blog/elfi-snack-anchors.html
@@ -42,11 +42,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/elfi-weiche.html
+++ b/pages/blog/elfi-weiche.html
@@ -42,11 +42,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/elfi-what-i-hear.html
+++ b/pages/blog/elfi-what-i-hear.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html">Ralf's Corner</a></li>
-                <li><a href="../elfi.html" class="active">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/gpt-image-2-switch.html
+++ b/pages/blog/gpt-image-2-switch.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/harness-inventory.html
+++ b/pages/blog/harness-inventory.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/hmze-semantic-anchors.html
+++ b/pages/blog/hmze-semantic-anchors.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/ide-is-dead.html
+++ b/pages/blog/ide-is-dead.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/ki-vs-entwickler.html
+++ b/pages/blog/ki-vs-entwickler.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/linkedwild-launch.html
+++ b/pages/blog/linkedwild-launch.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/llm-blind-spots.html
+++ b/pages/blog/llm-blind-spots.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/llms-kreativ.html
+++ b/pages/blog/llms-kreativ.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/mini-atam-review.html
+++ b/pages/blog/mini-atam-review.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/pyramid-principle.html
+++ b/pages/blog/pyramid-principle.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/raspberry-pi-llm.html
+++ b/pages/blog/raspberry-pi-llm.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/risk-radar-community.html
+++ b/pages/blog/risk-radar-community.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/risk-radar-runtime-modifier.html
+++ b/pages/blog/risk-radar-runtime-modifier.html
@@ -45,10 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/risk-radar-skills.html
+++ b/pages/blog/risk-radar-skills.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/semantic-anchors-catalog.html
+++ b/pages/blog/semantic-anchors-catalog.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/semantic-anchors-evaluation.html
+++ b/pages/blog/semantic-anchors-evaluation.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/semantic-anchors-six-months.html
+++ b/pages/blog/semantic-anchors-six-months.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/semantic-anchors-video.html
+++ b/pages/blog/semantic-anchors-video.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/semantic-anchors-webapp.html
+++ b/pages/blog/semantic-anchors-webapp.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/semantic-anchors.html
+++ b/pages/blog/semantic-anchors.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/semantic-contracts-live.html
+++ b/pages/blog/semantic-contracts-live.html
@@ -45,11 +45,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/semantic-contracts.html
+++ b/pages/blog/semantic-contracts.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/show-me-the-code.html
+++ b/pages/blog/show-me-the-code.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/silent-substitution.html
+++ b/pages/blog/silent-substitution.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/socratic-code-theory-recovery.html
+++ b/pages/blog/socratic-code-theory-recovery.html
@@ -92,11 +92,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/socratic-method-anchor.html
+++ b/pages/blog/socratic-method-anchor.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/socratic-recovery-tutorial.html
+++ b/pages/blog/socratic-recovery-tutorial.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/solid-semantic-anchor.html
+++ b/pages/blog/solid-semantic-anchor.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/tldr-semantic-anchor.html
+++ b/pages/blog/tldr-semantic-anchor.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/unscharfe-fotos.html
+++ b/pages/blog/unscharfe-fotos.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/vacuum-cleaner-duck-typing.html
+++ b/pages/blog/vacuum-cleaner-duck-typing.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/blog/vibe-coding-risk-radar.html
+++ b/pages/blog/vibe-coding-risk-radar.html
@@ -41,11 +41,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html" class="active">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html" class="active">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/datenschutz.html
+++ b/pages/datenschutz.html
@@ -29,11 +29,12 @@
             <a href="../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../index.html#about">Über mich</a></li>
+                <li><a href="../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../index.html#trainings">Trainings</a></li>
-                <li><a href="talks.html">Vorträge</a></li>
+                <li><a href="../pages/talks.html">Vorträge</a></li>
                 <li><a href="../index.html#publications">Publikationen</a></li>
-                <li><a href="blog.html">Ralf's Corner</a></li>
-                <li><a href="elfi.html">Elfi's Corner</a></li>
+                <li><a href="../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/elfi.html
+++ b/pages/elfi.html
@@ -24,11 +24,12 @@
             <a href="../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../index.html#about">Über mich</a></li>
+                <li><a href="../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../index.html#trainings">Trainings</a></li>
-                <li><a href="talks.html">Vorträge</a></li>
+                <li><a href="../pages/talks.html">Vorträge</a></li>
                 <li><a href="../index.html#publications">Publikationen</a></li>
-                <li><a href="blog.html">Ralf's Corner</a></li>
-                <li><a href="elfi.html" class="active">Elfi's Corner</a></li>
+                <li><a href="../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../pages/elfi.html" class="active">Elfi's Corner</a></li>
                 <li><a href="../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/hhgdac.html
+++ b/pages/hhgdac.html
@@ -29,11 +29,12 @@
             <a href="../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../index.html#about">Über mich</a></li>
+                <li><a href="../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../index.html#trainings">Trainings</a></li>
-                <li><a href="talks.html">Vorträge</a></li>
-                <li><a href="../index.html#publications" class="active">Publikationen</a></li>
-                <li><a href="blog.html">Ralf's Corner</a></li>
-                <li><a href="elfi.html">Elfi's Corner</a></li>
+                <li><a href="../pages/talks.html">Vorträge</a></li>
+                <li><a href="../index.html#publications">Publikationen</a></li>
+                <li><a href="../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/impressum.html
+++ b/pages/impressum.html
@@ -29,11 +29,12 @@
             <a href="../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../index.html#about">Über mich</a></li>
+                <li><a href="../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../index.html#trainings">Trainings</a></li>
-                <li><a href="talks.html">Vorträge</a></li>
+                <li><a href="../pages/talks.html">Vorträge</a></li>
                 <li><a href="../index.html#publications">Publikationen</a></li>
-                <li><a href="blog.html">Ralf's Corner</a></li>
-                <li><a href="elfi.html">Elfi's Corner</a></li>
+                <li><a href="../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/manifesto.de.html
+++ b/pages/manifesto.de.html
@@ -55,12 +55,12 @@
             <a href="../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../index.html#about">Über mich</a></li>
-                <li><a href="manifesto.html" class="active">Manifest</a></li>
+                <li><a href="../pages/manifesto.html" class="active">Manifest</a></li>
                 <li><a href="../index.html#trainings">Trainings</a></li>
-                <li><a href="../index.html#talks">Vorträge</a></li>
+                <li><a href="../pages/talks.html">Vorträge</a></li>
                 <li><a href="../index.html#publications">Publikationen</a></li>
-                <li><a href="blog.html">Ralf's Corner</a></li>
-                <li><a href="elfi.html">Elfi's Corner</a></li>
+                <li><a href="../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/manifesto.html
+++ b/pages/manifesto.html
@@ -55,12 +55,12 @@
             <a href="../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../index.html#about">Über mich</a></li>
-                <li><a href="manifesto.html" class="active">Manifest</a></li>
+                <li><a href="../pages/manifesto.html" class="active">Manifest</a></li>
                 <li><a href="../index.html#trainings">Trainings</a></li>
-                <li><a href="../index.html#talks">Vorträge</a></li>
+                <li><a href="../pages/talks.html">Vorträge</a></li>
                 <li><a href="../index.html#publications">Publikationen</a></li>
-                <li><a href="blog.html">Ralf's Corner</a></li>
-                <li><a href="elfi.html">Elfi's Corner</a></li>
+                <li><a href="../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/profiles/elfi.html
+++ b/pages/profiles/elfi.html
@@ -186,12 +186,13 @@
         <div class="container">
             <a href="../../index.html" class="logo">Ralf D. M&uuml;ller</a>
             <ul class="nav-links">
-                <li><a href="../../index.html#about">&Uuml;ber mich</a></li>
+                <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vortr&auml;ge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html">Ralf's Corner</a></li>
-                <li><a href="../elfi.html" class="active">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html" class="active">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Men&uuml; &ouml;ffnen">

--- a/pages/profiles/lala.html
+++ b/pages/profiles/lala.html
@@ -86,11 +86,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html" class="active">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/profiles/madame.html
+++ b/pages/profiles/madame.html
@@ -86,11 +86,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html" class="active">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/profiles/peter.html
+++ b/pages/profiles/peter.html
@@ -86,11 +86,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html" class="active">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/profiles/ringo.html
+++ b/pages/profiles/ringo.html
@@ -95,11 +95,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html">Vorträge</a></li>
+                <li><a href="../../pages/talks.html">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html" class="active">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/talks.html
+++ b/pages/talks.html
@@ -29,11 +29,12 @@
             <a href="../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../index.html#about">Über mich</a></li>
+                <li><a href="../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../index.html#trainings">Trainings</a></li>
-                <li><a href="talks.html" class="active">Vorträge</a></li>
+                <li><a href="../pages/talks.html" class="active">Vorträge</a></li>
                 <li><a href="../index.html#publications">Publikationen</a></li>
-                <li><a href="blog.html">Ralf's Corner</a></li>
-                <li><a href="elfi.html">Elfi's Corner</a></li>
+                <li><a href="../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/pages/talks/spec-driven-agentic-coding.html
+++ b/pages/talks/spec-driven-agentic-coding.html
@@ -52,11 +52,12 @@
             <a href="../../index.html" class="logo">Ralf D. Müller</a>
             <ul class="nav-links">
                 <li><a href="../../index.html#about">Über mich</a></li>
+                <li><a href="../../pages/manifesto.html">Manifest</a></li>
                 <li><a href="../../index.html#trainings">Trainings</a></li>
-                <li><a href="../talks.html" class="active">Vorträge</a></li>
+                <li><a href="../../pages/talks.html" class="active">Vorträge</a></li>
                 <li><a href="../../index.html#publications">Publikationen</a></li>
-                <li><a href="../blog.html">Ralf's Corner</a></li>
-                <li><a href="../elfi.html">Elfi's Corner</a></li>
+                <li><a href="../../pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="../../pages/elfi.html">Elfi's Corner</a></li>
                 <li><a href="../../index.html#contact">Kontakt</a></li>
             </ul>
             <button class="mobile-menu-btn" aria-label="Menü öffnen">

--- a/scripts/nav-snippet.html
+++ b/scripts/nav-snippet.html
@@ -1,0 +1,22 @@
+<!--
+Canonical nav-links snippet. Single source of truth for site navigation.
+Edit this file, then run `python3 scripts/sync-nav.py` to propagate the
+nav across every HTML file in the repo.
+
+Placeholders:
+  {ROOT}     replaced with the relative path back to the repo root for
+             each file (empty at the root, "../" inside pages/, etc.)
+
+Active state is set automatically by sync-nav.py based on file path.
+Do not add class="active" here.
+-->
+<ul class="nav-links">
+                <li><a href="{ROOT}index.html#about">Über mich</a></li>
+                <li><a href="{ROOT}pages/manifesto.html">Manifest</a></li>
+                <li><a href="{ROOT}index.html#trainings">Trainings</a></li>
+                <li><a href="{ROOT}pages/talks.html">Vorträge</a></li>
+                <li><a href="{ROOT}index.html#publications">Publikationen</a></li>
+                <li><a href="{ROOT}pages/blog.html">Ralf's Corner</a></li>
+                <li><a href="{ROOT}pages/elfi.html">Elfi's Corner</a></li>
+                <li><a href="{ROOT}index.html#contact">Kontakt</a></li>
+            </ul>

--- a/scripts/sync-nav.py
+++ b/scripts/sync-nav.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Sync the canonical nav across all HTML files in the repo.
+
+Reads scripts/nav-snippet.html (with {ROOT} placeholders) and rewrites the
+<ul class="nav-links">...</ul> block in every HTML file, computing the
+relative root prefix from the file's depth and marking the active item
+based on path rules.
+
+Usage:
+    python3 scripts/sync-nav.py            # apply changes
+    python3 scripts/sync-nav.py --check    # exit 1 if any file would change
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SNIPPET_PATH = ROOT / "scripts" / "nav-snippet.html"
+
+NAV_RE = re.compile(r'<ul class="nav-links">.*?</ul>', re.DOTALL)
+
+ACTIVE_RULES = [
+    (re.compile(r'^pages/manifesto(\.de)?\.html$'), 'Manifest'),
+    (re.compile(r'^pages/blog\.html$'), "Ralf's Corner"),
+    (re.compile(r'^pages/blog/.*\.html$'), "Ralf's Corner"),
+    (re.compile(r'^pages/elfi\.html$'), "Elfi's Corner"),
+    (re.compile(r'^pages/profiles/.*\.html$'), "Elfi's Corner"),
+    (re.compile(r'^pages/talks\.html$'), "Vorträge"),
+    (re.compile(r'^pages/talks/.*\.html$'), "Vorträge"),
+]
+
+SKIP_DIRS = {"node_modules", ".git"}
+
+
+def load_snippet() -> str:
+    text = SNIPPET_PATH.read_text(encoding="utf-8")
+    m = NAV_RE.search(text)
+    if not m:
+        raise SystemExit(f"ERROR: {SNIPPET_PATH} does not contain <ul class=\"nav-links\">")
+    return m.group(0)
+
+
+def render_nav(snippet: str, root_prefix: str, active_label: str | None) -> str:
+    nav = snippet.replace("{ROOT}", root_prefix)
+    if active_label:
+        pattern = re.compile(
+            r'(<a href="[^"]*")(>' + re.escape(active_label) + r'</a>)'
+        )
+        nav = pattern.sub(r'\1 class="active"\2', nav, count=1)
+    return nav
+
+
+def active_for(rel_str: str) -> str | None:
+    for pattern, label in ACTIVE_RULES:
+        if pattern.match(rel_str):
+            return label
+    return None
+
+
+def iter_html_files():
+    for path in ROOT.rglob("*.html"):
+        if any(part in SKIP_DIRS for part in path.relative_to(ROOT).parts):
+            continue
+        if path == SNIPPET_PATH:
+            continue
+        yield path
+
+
+def sync(check_only: bool) -> int:
+    snippet = load_snippet()
+    changed: list[str] = []
+    skipped: list[str] = []
+
+    for html_file in iter_html_files():
+        rel = html_file.relative_to(ROOT)
+        rel_str = "/".join(rel.parts)
+        root_prefix = "../" * (len(rel.parts) - 1)
+        new_nav = render_nav(snippet, root_prefix, active_for(rel_str))
+
+        text = html_file.read_text(encoding="utf-8")
+        match = NAV_RE.search(text)
+        if not match:
+            skipped.append(rel_str)
+            continue
+        if match.group(0) == new_nav:
+            continue
+
+        new_text = text[: match.start()] + new_nav + text[match.end():]
+        changed.append(rel_str)
+        if not check_only:
+            html_file.write_text(new_text, encoding="utf-8")
+
+    if changed:
+        verb = "would update" if check_only else "updated"
+        print(f"{verb} {len(changed)} file(s):")
+        for f in changed:
+            print(f"  {f}")
+    else:
+        print("All nav blocks already in sync.")
+
+    if skipped:
+        print(f"\nNote: {len(skipped)} file(s) without nav-links (skipped).")
+
+    return 1 if (check_only and changed) else 0
+
+
+def main() -> int:
+    check_only = "--check" in sys.argv[1:]
+    return sync(check_only)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Eliminates the nav drift across the site by introducing a canonical nav snippet plus a sync script.

- `scripts/nav-snippet.html` — single source of truth for the `<ul class="nav-links">` block, with `{ROOT}` placeholder for the depth-relative path back to the repo root
- `scripts/sync-nav.py` — walks every HTML file, computes the right `{ROOT}` prefix, applies the snippet, and sets `class="active"` based on path rules (Manifest, Ralf's Corner, Elfi's Corner, Vorträge)
- `--check` mode exits non-zero if any file would change. Drop it into CI later if you want PR-time enforcement.

## Drift that this PR fixes

The audit before this PR found 5 distinct nav variants across 82 files:

| Count | Variant |
|------:|---------|
| 74 | Standard nav without the Manifest entry I added this week |
| 3 | Old blog posts predating Elfi's Corner |
| 1 | `pages/blog.html` used the label "Blog" instead of "Ralf's Corner" |
| 1 | `pages/profiles/elfi.html` used HTML entities (`&Uuml;ber`) instead of UTF-8 |
| 3 | The pages I touched this week, with Manifest |

After this PR: 1 variant, generated from one source, 82 files in sync.

## Workflow

- Edit `scripts/nav-snippet.html`
- Run `python3 scripts/sync-nav.py`
- Commit the resulting diff together with the snippet change
- Or run `python3 scripts/sync-nav.py --check` to verify no drift before pushing

## Future extensions

The same mechanism could later carry footer, head-meta, OG-tag scaffolding, etc. — micro-templating without an SSG migration. Not part of this PR.

## Test plan

- [x] `--check` exits 1 when drift exists, 0 when in sync
- [x] After applying, `--check` reports "All nav blocks already in sync"
- [x] Verified link resolution from index.html, pages/blog.html, and a nested blog post
- [x] Active state correct on manifesto, manifesto.de, blog.html, profiles/elfi.html
- [ ] Visual check across desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)