### PR TITLE
manifesto: second-pass English translation

### DIFF
--- a/pages/manifesto.html
+++ b/pages/manifesto.html
@@ -86,38 +86,38 @@
             </header>
 
             <div class="article-content">
-                <p>I am a software architect. I stopped asking <em>what</em> GenAI is and started using <em>what</em> it can do.</p>
+                <p>I'm a software architect. I stopped asking <em>what</em> GenAI is and started using <em>what</em> it can do.</p>
 
-                <p>The interesting discussion has moved on. I am moving with it.</p>
+                <p>The interesting discussion has moved on. I'm moving with it.</p>
 
                 <h2>Where I stand</h2>
 
                 <p><strong>I accept GenAI as a form of intelligence.</strong><br>
-                Whether it is „really" intelligent does not get me anywhere. I look at what these systems deliver, and I work with that.</p>
+                Whether it's "really" intelligent is beside the point. I look at what these systems deliver, and I work with that.</p>
 
                 <p><strong>I define capabilities independently of humans.</strong><br>
-                Tying terms like creativity, understanding, and intelligence firmly to humans — „creativity is what humans do" — narrows the field and makes new forms invisible before you look. I measure such capabilities by their properties and effects, not by their origin. That takes nothing away from humans. It widens the view.</p>
+                Tying terms like creativity, understanding, and intelligence firmly to humans — "creativity is what humans do" — narrows the field and makes new forms invisible before anyone takes a look. I measure such capabilities by their properties and effects, not by their origin. That takes nothing away from humans. It widens the view.</p>
 
-                <p><strong>I do not wait for AGI.</strong><br>
-                Waiting for a term nobody can define is not a strategy. It is an excuse. I work with what is on the table today, and that is more than enough.</p>
+                <p><strong>I don't wait for AGI.</strong><br>
+                Waiting for a term nobody can define isn't a strategy. It's an excuse. I work with what's on the table today, and that's more than enough.</p>
 
                 <p><strong>Pandora's box is open.</strong><br>
-                GenAI is in the world, and nobody is putting it back. The question is not <em>whether</em>, but <em>how</em>. I anticipate and shape, instead of waiting for „all this to settle down". It will not.</p>
+                GenAI is in the world, and nobody is putting it back. The question isn't <em>whether</em>, but <em>how</em>. I anticipate and shape, instead of waiting for "all this to settle down". It won't.</p>
 
-                <p><strong>I do not apply GenAI blindly. I understand it.</strong><br>
-                Using GenAI sensibly is an engineering discipline. You do not read a specification, you investigate a behavior. So I work empirically and want to know <em>why</em> something works, <em>where</em> it breaks, and <em>when</em> you should not trust it. That protects against cargo cult on one side and fear on the other.</p>
+                <p><strong>I don't apply GenAI blindly. I understand it.</strong><br>
+                Using GenAI sensibly is an engineering discipline. You don't read a specification, you investigate a behavior. So I work empirically and want to know <em>why</em> something works, <em>where</em> it breaks, and <em>when</em> you shouldn't trust it. That protects against cargo cult on one side and fear on the other.</p>
 
                 <p><strong>I bring craft, not just enthusiasm.</strong><br>
-                A language model does not replace architecture, clarity about the problem, or discipline in building. That is exactly what I bring. The tools are new. The standard for good work is not.</p>
+                A language model doesn't replace architecture, clarity about the problem, or discipline in building. That's exactly what I bring. The tools are new. The standard for good work isn't.</p>
 
                 <p><strong>I use GenAI for people, not against them.</strong><br>
-                I do not measure it by what it promises, but by what it does when it costs something. AI that surveils people, demeans them, or floods them with disinformation — or that gets let loose without human accountability — is not what I mean. No matter whose logo is on it.</p>
+                I don't measure it by what it promises, but by what it does when it costs something. AI that surveils people, demeans them, or floods them with disinformation — or is set loose without human accountability — isn't what I mean. No matter whose logo is on it.</p>
 
                 <p><strong>Real control beats the ritual of control.</strong><br>
-                A mandatory review that ends in review fatigue is narrated safety, a checkmark without substance. Where human inspection no longer truly catches things, I build safety into the process: into tests, into architecture, into workflows that catch errors. The human is not the gate. The human is the one who builds the system so it holds.</p>
+                A mandatory review that ends in review fatigue is safety theater, a checkmark without substance. Where human inspection no longer truly catches things, I build safety into the process: into tests, into architecture, into workflows that catch errors. The human isn't the gate. The human is the one who builds the system so it holds.</p>
 
-                <p><strong>The duty to label AI will outlive itself.</strong><br>
-                Today, a marker is supposed to warn: „a machine was here". But once almost everything is AI-touched, the marker marks nothing. A warning on everything is no warning. What matters moves from origin to care: not <em>whether</em> a machine was involved, but <em>how</em> it was checked.</p>
+                <p><strong>The duty to label AI will undo itself.</strong><br>
+                Today, a marker is supposed to warn: "a machine was here". But once almost everything is AI-touched, the marker means nothing. A warning on everything is no warning. What matters moves from origin to care: not <em>whether</em> a machine was involved, but <em>how</em> it was checked.</p>
 
                 <h2>In short</h2>
 
@@ -131,9 +131,9 @@
 
                 <h2>What I want to talk about</h2>
 
-                <p>If you want to explain to me over dinner why „AI doesn't really understand anything", that is an interesting conversation. It just is not mine.</p>
+                <p>If you want to explain to me over dinner why "AI doesn't really understand anything", that's an interesting conversation. But it isn't mine.</p>
 
-                <p>If you would rather show me what you built with it last week: any time.</p>
+                <p>If you'd rather show me what you built with it last week: any time.</p>
             </div>
 
             <footer class="article-footer">


### PR DESCRIPTION
## Summary

Three classes of issues from the first translation, fixed in one pass.

### 1. German quotation marks in English text

The first translation left German low/high quote pairs (`„…"`) in the English version. They read as untranslated artifact. Replaced with English straight quotes throughout.

### 2. Register too formal

The German original is conversational. The English used `do not / does not / is not / I am` throughout, which read more like a corporate declaration than a personal manifesto. Native English manifestos (Cluetrain, Agile, Stallman) use contractions. Added contractions everywhere.

### 3. Phrases that read as translation

| Before | After |
|---|---|
| does not get me anywhere | is beside the point |
| makes new forms invisible before you look | makes new forms invisible before anyone takes a look |
| or that gets let loose without human accountability | or is set loose without human accountability |
| It just is not mine | But it isn't mine |
| The duty to label AI will outlive itself | The duty to label AI will undo itself |
| is narrated safety | is safety theater |
| the marker marks nothing | the marker means nothing |

`safety theater` lands particularly well because it's an established English term for performative-but-ineffective safety measures, which is exactly Ralf's point.

## Out of scope

The German version is untouched. The structure, headings, and the nine principles are the same.

## Test plan

- [x] grep verifies no German low-quote (`„`, U+201E) and no curly quotes remain
- [x] Page returns 200 from local server
- [ ] Browser read-through to confirm cadence

🤖 Generated with [Claude Code](https://claude.com/claude-code)