### PR TITLE
manifesto: two final English-translation tweaks

### DIFF
--- a/pages/manifesto.html
+++ b/pages/manifesto.html
@@ -96,7 +96,7 @@
                 Whether it's "really" intelligent is beside the point. I look at what these systems deliver, and I work with that.</p>
 
                 <p><strong>I define capabilities independently of humans.</strong><br>
-                Tying terms like creativity, understanding, and intelligence firmly to humans — "creativity is what humans do" — narrows the field and makes new forms invisible before anyone takes a look. I measure such capabilities by their properties and effects, not by their origin. That takes nothing away from humans. It widens the view.</p>
+                Tying terms like creativity, understanding, and intelligence firmly to humans — "creativity is what humans do" — narrows the field and makes new forms invisible before anyone bothers to look. I measure such capabilities by their properties and effects, not by their origin. That takes nothing away from humans. It widens the view.</p>
 
                 <p><strong>I don't wait for AGI.</strong><br>
                 Waiting for a term nobody can define isn't a strategy. It's an excuse. I work with what's on the table today, and that's more than enough.</p>
@@ -105,7 +105,7 @@
                 GenAI is in the world, and nobody is putting it back. The question isn't <em>whether</em>, but <em>how</em>. I anticipate and shape, instead of waiting for "all this to settle down". It won't.</p>
 
                 <p><strong>I don't apply GenAI blindly. I understand it.</strong><br>
-                Using GenAI sensibly is an engineering discipline. You don't read a specification, you investigate a behavior. So I work empirically and want to know <em>why</em> something works, <em>where</em> it breaks, and <em>when</em> you shouldn't trust it. That protects against cargo cult on one side and fear on the other.</p>
+                Using GenAI sensibly is an engineering discipline. You don't read a specification — you investigate a behavior. So I work empirically and want to know <em>why</em> something works, <em>where</em> it breaks, and <em>when</em> you shouldn't trust it. That protects against cargo cult on one side and fear on the other.</p>
 
                 <p><strong>I bring craft, not just enthusiasm.</strong><br>
                 A language model doesn't replace architecture, clarity about the problem, or discipline in building. That's exactly what I bring. The tools are new. The standard for good work isn't.</p>


### PR DESCRIPTION
## Summary

Two small follow-ups from the second-pass review:

1. `"before anyone takes a look"` → `"before anyone bothers to look"` — removes the last whiff of translation.
2. `"You don't read a specification, you investigate a behavior."` → em-dash instead of comma splice. Both forms work in a manifesto, but the em-dash sharpens the contrast.

## Out of scope

German version untouched. Two-line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)