### PR TITLE
Add missing LinkedWild comments section to agentic-coding-weekend

### DIFF
--- a/pages/blog/agentic-coding-weekend.html
+++ b/pages/blog/agentic-coding-weekend.html
@@ -108,6 +108,11 @@
                 <p><em>PS: this is a game changer for those unpaid, single-maintainer open source projects.</em></p>
             </div>
 
+            <section class="comments-section" id="linkedwild-comments">
+                <h2>LinkedWild</h2>
+                <div class="comments-list" id="character-comments"></div>
+            </section>
+
             <footer class="article-footer">
                 <div class="article-tags">
                     <span class="blog-tag">Agentic Coding</span>


### PR DESCRIPTION
The page lacked the `#character-comments` container. comments.js exits silently when it does not find it, so the three character comments on Discussion #148 were not rendering on the live site.